### PR TITLE
emptyList에 empty string이 담겨 반환되는 이슈 해결

### DIFF
--- a/src/main/java/com/Lommunity/domain/common/ListStringConverter.java
+++ b/src/main/java/com/Lommunity/domain/common/ListStringConverter.java
@@ -2,6 +2,7 @@ package com.Lommunity.domain.common;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ public class ListStringConverter implements AttributeConverter<List<String>, Str
 
     @Override
     public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData.isEmpty()) return new ArrayList<>();
         return Arrays.stream(dbData.split(SPLIT_CHAR))
                      .collect(Collectors.toList());
     }


### PR DESCRIPTION
- 이미지가 없는 게시물을 조회하였을 때 profileImageUrls가 [""]로 반환된다. 이것을 []이 반환되도록 수정하기